### PR TITLE
Fixed sign up and user agreement buttons spacing, adjusted confirmati…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         <activity android:name=".activities.SignUpActivity" />
         <activity android:name=".activities.SignUpConfirmationActivity" />
         <activity android:name=".activities.LogInActivity" />
-        <activity android:name=".activities.UserSettingsActivity" />
+        <activity android:name=".activities.SettingsActivity" />
         <activity android:name=".activities.MeasurementDetailActivity" />
         <activity android:name=".activities.DistillerySettingsActivity" />
         <activity android:name=".activities.NewBatchActivity" />

--- a/app/src/main/java/com/trueproof/trueproof/activities/MainActivity.java
+++ b/app/src/main/java/com/trueproof/trueproof/activities/MainActivity.java
@@ -174,7 +174,6 @@ public class MainActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem menuItem){
         if (menuItem.getItemId() == R.id.nav_settings)MainActivity.this.startActivity(new Intent(MainActivity.this, DistillerySettingsActivity.class));
         if (menuItem.getItemId() == R.id.nav_batch_list)MainActivity.this.startActivity(new Intent(MainActivity.this, BatchListActivity.class));
-        if (menuItem.getItemId() == R.id.nav_settings)MainActivity.this.startActivity(new Intent(MainActivity.this, DistillerySettingsActivity.class));
         if (menuItem.getItemId() == R.id.nav_quick_calculator)MainActivity.this.startActivity(new Intent(MainActivity.this, TakeMeasurementActivity.class));
         return true;
         }

--- a/app/src/main/java/com/trueproof/trueproof/activities/SettingsActivity.java
+++ b/app/src/main/java/com/trueproof/trueproof/activities/SettingsActivity.java
@@ -16,7 +16,7 @@ import com.trueproof.trueproof.utils.MeasurementRepository;
 
 import org.jetbrains.annotations.NotNull;
 
-public class UserSettingsActivity extends AppCompatActivity {
+public class SettingsActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -87,7 +87,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/editTextDSP" />
+        app:layout_constraintTop_toBottomOf="@+id/userAgreementButton" />
 
     <TextView
         android:id="@+id/labelForEmail"
@@ -134,12 +134,13 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:backgroundTint="#DF4444"
-        android:paddingLeft="8dp"
-        android:paddingTop="2dp"
-        android:paddingRight="8dp"
-        android:paddingBottom="2dp"
+        android:paddingLeft="4dp"
+        android:paddingTop="1dp"
+        android:paddingRight="4dp"
+        android:paddingBottom="1dp"
         android:text="@string/userAgreementButtonText"
         android:textSize="12sp"
+        app:layout_constraintBottom_toTopOf="@+id/buttonSignupSignup"
         app:layout_constraintStart_toStartOf="@+id/editTextDSP"
         app:layout_constraintTop_toBottomOf="@+id/editTextDSP" />
 
@@ -149,11 +150,11 @@
         android:layout_height="wrap_content"
         android:ems="10"
         android:hint="@string/shortDSPNumberText"
+        android:importantForAutofill="no"
         android:inputType="textPersonName"
         app:layout_constraintBottom_toTopOf="@+id/buttonSignupSignup"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/editTextPasswordConfirmationSignup"
-        android:importantForAutofill="no" />
+        app:layout_constraintTop_toBottomOf="@+id/editTextPasswordConfirmationSignup" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_sign_up_confirmation.xml
+++ b/app/src/main/res/layout/activity_sign_up_confirmation.xml
@@ -12,6 +12,7 @@
         android:layout_height="wrap_content"
         android:text="Confirmation"
         android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/textViewBodyConfirmation"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
@@ -19,9 +20,10 @@
 
     <TextView
         android:id="@+id/textViewBodyConfirmation"
-        android:layout_width="392dp"
-        android:layout_height="104dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginTop="30dp"
+        android:breakStrategy="high_quality"
         android:text="@string/confirmationDescriptionText"
         android:textSize="20sp"
         app:layout_constraintBottom_toTopOf="@+id/editTextConfirmationCodeConfirmation"

--- a/app/src/main/res/layout/activity_user_settings.xml
+++ b/app/src/main/res/layout/activity_user_settings.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".activities.UserSettingsActivity">
+    tools:context=".activities.SettingsActivity">
 
     <TextView
         android:id="@+id/textViewDSPTitleUserSettings"


### PR DESCRIPTION
Fixed sign up and user agreement buttons spacing, adjusted confirmation on layout to look properly on smaller phones, renamed UserSettingsActivty SettingsActivity and deleted a line in main so that the menu inflater doesn't start two intents of the settings activity