### PR TITLE
Batch repository and make status required

### DIFF
--- a/amplify/backend/api/trueproofAPI/schema.graphql
+++ b/amplify/backend/api/trueproofAPI/schema.graphql
@@ -15,7 +15,7 @@ type Batch @model
     distilleryID: ID!
     batchIdentifier: String
     batchNumber: Int
-    status: Status
+    status: Status!
     type: String
     completedAt: AWSDateTime
     """

--- a/app/src/main/graphql/schema.json
+++ b/app/src/main/graphql/schema.json
@@ -1783,9 +1783,13 @@
                         "description": null,
                         "args": [],
                         "type": {
-                            "kind": "ENUM",
-                            "name": "Status",
-                            "ofType": null
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "ENUM",
+                                "name": "Status",
+                                "ofType": null
+                            }
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
@@ -3700,9 +3704,13 @@
                         "name": "status",
                         "description": null,
                         "type": {
-                            "kind": "ENUM",
-                            "name": "Status",
-                            "ofType": null
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "ENUM",
+                                "name": "Status",
+                                "ofType": null
+                            }
                         },
                         "defaultValue": null
                     },

--- a/app/src/main/java/com/amplifyframework/datastore/generated/model/AmplifyModelProvider.java
+++ b/app/src/main/java/com/amplifyframework/datastore/generated/model/AmplifyModelProvider.java
@@ -13,7 +13,7 @@ import java.util.Set;
  */
 
 public final class AmplifyModelProvider implements ModelProvider {
-  private static final String AMPLIFY_MODEL_VERSION = "a738d2b8b18233e6859cfb7546eb5add";
+  private static final String AMPLIFY_MODEL_VERSION = "35fb464d1f64a00362a0cba6dda2f5ca";
   private static AmplifyModelProvider amplifyGeneratedModelInstance;
   private AmplifyModelProvider() {
     

--- a/app/src/main/java/com/amplifyframework/datastore/generated/model/Batch.java
+++ b/app/src/main/java/com/amplifyframework/datastore/generated/model/Batch.java
@@ -35,7 +35,7 @@ public final class Batch implements Model {
   private final @ModelField(targetType="ID", isRequired = true) String id;
   private final @ModelField(targetType="String") String batchIdentifier;
   private final @ModelField(targetType="Int") Integer batchNumber;
-  private final @ModelField(targetType="Status") Status status;
+  private final @ModelField(targetType="Status", isRequired = true) Status status;
   private final @ModelField(targetType="String") String type;
   private final @ModelField(targetType="AWSDateTime") Temporal.DateTime completedAt;
   private final @ModelField(targetType="AWSDateTime") Temporal.DateTime createdAt;
@@ -147,7 +147,7 @@ public final class Batch implements Model {
       .toString();
   }
   
-  public static BuildStep builder() {
+  public static StatusStep builder() {
       return new Builder();
   }
   
@@ -194,12 +194,16 @@ public final class Batch implements Model {
       updatedAt,
       distillery);
   }
+  public interface StatusStep {
+    BuildStep status(Status status);
+  }
+  
+
   public interface BuildStep {
     Batch build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep batchIdentifier(String batchIdentifier);
     BuildStep batchNumber(Integer batchNumber);
-    BuildStep status(Status status);
     BuildStep type(String type);
     BuildStep completedAt(Temporal.DateTime completedAt);
     BuildStep createdAt(Temporal.DateTime createdAt);
@@ -208,11 +212,11 @@ public final class Batch implements Model {
   }
   
 
-  public static class Builder implements BuildStep {
+  public static class Builder implements StatusStep, BuildStep {
     private String id;
+    private Status status;
     private String batchIdentifier;
     private Integer batchNumber;
-    private Status status;
     private String type;
     private Temporal.DateTime completedAt;
     private Temporal.DateTime createdAt;
@@ -235,6 +239,13 @@ public final class Batch implements Model {
     }
     
     @Override
+     public BuildStep status(Status status) {
+        Objects.requireNonNull(status);
+        this.status = status;
+        return this;
+    }
+    
+    @Override
      public BuildStep batchIdentifier(String batchIdentifier) {
         this.batchIdentifier = batchIdentifier;
         return this;
@@ -243,12 +254,6 @@ public final class Batch implements Model {
     @Override
      public BuildStep batchNumber(Integer batchNumber) {
         this.batchNumber = batchNumber;
-        return this;
-    }
-    
-    @Override
-     public BuildStep status(Status status) {
-        this.status = status;
         return this;
     }
     
@@ -307,14 +312,19 @@ public final class Batch implements Model {
   public final class CopyOfBuilder extends Builder {
     private CopyOfBuilder(String id, String batchIdentifier, Integer batchNumber, Status status, String type, Temporal.DateTime completedAt, Temporal.DateTime createdAt, Temporal.DateTime updatedAt, Distillery distillery) {
       super.id(id);
-      super.batchIdentifier(batchIdentifier)
+      super.status(status)
+        .batchIdentifier(batchIdentifier)
         .batchNumber(batchNumber)
-        .status(status)
         .type(type)
         .completedAt(completedAt)
         .createdAt(createdAt)
         .updatedAt(updatedAt)
         .distillery(distillery);
+    }
+    
+    @Override
+     public CopyOfBuilder status(Status status) {
+      return (CopyOfBuilder) super.status(status);
     }
     
     @Override
@@ -325,11 +335,6 @@ public final class Batch implements Model {
     @Override
      public CopyOfBuilder batchNumber(Integer batchNumber) {
       return (CopyOfBuilder) super.batchNumber(batchNumber);
-    }
-    
-    @Override
-     public CopyOfBuilder status(Status status) {
-      return (CopyOfBuilder) super.status(status);
     }
     
     @Override

--- a/app/src/main/java/com/trueproof/trueproof/utils/BatchRepository.java
+++ b/app/src/main/java/com/trueproof/trueproof/utils/BatchRepository.java
@@ -66,15 +66,16 @@ public class BatchRepository {
     public void getActiveBatchesByDistillery(Distillery distillery, Consumer<List<Batch>> onSuccess, Consumer<ApiException> onFail) {
         List<Batch> output = new ArrayList<>();
         Amplify.API.query(
-                ModelQuery.list(Batch.class, Batch.DISTILLERY.contains(distillery.getId())),
+                ModelQuery.list(Batch.class,
+                        Batch.DISTILLERY.eq(distillery.getId())
+                        .and(Batch.STATUS.eq(Status.ACTIVE))
+                ),
                 response -> {
                     for (Batch batch : response.getData()) {
-                        if (batch.getStatus().equals(Status.ACTIVE)) output.add(batch);
-
+                        output.add(batch);
                     }
                     onSuccess.accept(output);
                 },
-
                 onFail
         );
     }
@@ -82,23 +83,22 @@ public class BatchRepository {
     public void getCompleteBatchesByDistillery(Distillery distillery, Consumer<List<Batch>> onSuccess, Consumer<ApiException> onFail) {
         List<Batch> output = new ArrayList<>();
         Amplify.API.query(
-                ModelQuery.list(Batch.class, Batch.DISTILLERY.contains(distillery.getId())),
+                ModelQuery.list(Batch.class,
+                        Batch.DISTILLERY.eq(distillery.getId())
+                        .and(Batch.STATUS.eq(Status.COMPLETE))
+                ),
                 response -> {
                     for (Batch batch : response.getData()) {
-                        if (batch.getStatus().equals(Status.COMPLETE)) output.add(batch);
-
+                        output.add(batch);
                     }
                     onSuccess.accept(output);
                 },
-
                 onFail
         );
     }
 
     public void deleteBatch (Batch batch, Consumer onSuccess, Consumer<ApiException>onFail){
-
             Amplify.API.mutate(ModelMutation.delete(batch), onSuccess, onFail);
-
     }
 
 }


### PR DESCRIPTION
- [X] Status is now a required field on Batch in the graphql schema
- [X] Batch repository now uses database query to filter out complete or active batches