### PR TITLE
Create and register deserializer for AWS DateTime object

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,6 +50,13 @@ dependencies {
     // Dependency injection with Hilt
     implementation "com.google.dagger:hilt-android:$hilt_version"
     kapt "com.google.dagger:hilt-compiler:$hilt_version"
+    // For instrumented tests.
+    androidTestImplementation 'com.google.dagger:hilt-android-testing:2.35'
+    // ...with Kotlin.
+    kaptAndroidTest 'com.google.dagger:hilt-android-compiler:2.35'
+    // ...with Java.
+    androidTestAnnotationProcessor 'com.google.dagger:hilt-android-compiler:2.35'
+
 
     // Amplify framework
     implementation 'com.amplifyframework:core:1.17.5'

--- a/app/src/main/java/com/trueproof/trueproof/utils/JsonConverter.java
+++ b/app/src/main/java/com/trueproof/trueproof/utils/JsonConverter.java
@@ -1,9 +1,26 @@
 package com.trueproof.trueproof.utils;
 
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
+import com.amplifyframework.core.model.temporal.Temporal;
 import com.amplifyframework.datastore.generated.model.Batch;
 import com.amplifyframework.datastore.generated.model.Distillery;
 import com.amplifyframework.datastore.generated.model.Measurement;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -14,27 +31,61 @@ public class JsonConverter {
 
     @Inject
     public JsonConverter() {
-         gson = new Gson();
+        gson = new GsonBuilder()
+                .registerTypeAdapter(Temporal.DateTime.class, new TemporalDateTimeDeserializer())
+                .create();
     }
 
-
-
-    public String measurementToJson (Measurement measurement){
+    public String measurementToJson(Measurement measurement) {
         return gson.toJson(measurement);
     }
-    public String batchToJson (Batch batch){
+
+    public String batchToJson(Batch batch) {
         return gson.toJson(batch);
     }
-    public String distilleryToJson (Distillery distillery){
+
+    public String distilleryToJson(Distillery distillery) {
         return gson.toJson(distillery);
     }
-    public Measurement measurementFromJson (String json){
-         return gson.fromJson(json, Measurement.class);
+
+    public Measurement measurementFromJson(String json) {
+        return gson.fromJson(json, Measurement.class);
     }
-    public Batch batchFromJson (String json){
+
+    public Batch batchFromJson(String json) {
         return gson.fromJson(json, Batch.class);
     }
-    public Distillery distilleryFromJson (String json){
+
+    public Distillery distilleryFromJson(String json) {
         return gson.fromJson(json, Distillery.class);
+    }
+
+    private static final class TemporalDateTimeDeserializer implements JsonDeserializer<Temporal.DateTime> {
+        @RequiresApi(api = Build.VERSION_CODES.O)
+        @Override
+        public Temporal.DateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            JsonObject jsonObject = json.getAsJsonObject();
+            JsonObject offsetDateTime = jsonObject.get("offsetDateTime").getAsJsonObject();
+            JsonObject dateTime = offsetDateTime.get("dateTime").getAsJsonObject();
+            int offsetTotalSeconds = offsetDateTime.get("offset").getAsJsonObject()
+                    .get("totalSeconds").getAsInt();
+
+            JsonObject date = dateTime.get("date").getAsJsonObject();
+            JsonObject time = dateTime.get("time").getAsJsonObject();
+
+            OffsetDateTime odt = OffsetDateTime.of(
+                    date.get("year").getAsInt(),
+                    date.get("month").getAsInt(),
+                    date.get("day").getAsInt(),
+                    time.get("hour").getAsInt(),
+                    time.get("minute").getAsInt(),
+                    time.get("second").getAsInt(),
+                    time.get("nano").getAsInt(),
+                    ZoneOffset.ofTotalSeconds(offsetTotalSeconds)
+            );
+
+            return new Temporal.DateTime(odt.toString());
+        }
     }
 }

--- a/app/src/test/java/com/trueproof/trueproof/utils/JsonConverterTest.java
+++ b/app/src/test/java/com/trueproof/trueproof/utils/JsonConverterTest.java
@@ -1,0 +1,56 @@
+package com.trueproof.trueproof.utils;
+
+import com.amplifyframework.core.model.temporal.Temporal;
+import com.amplifyframework.datastore.generated.model.Batch;
+import com.amplifyframework.datastore.generated.model.Distillery;
+import com.amplifyframework.datastore.generated.model.Measurement;
+import com.amplifyframework.datastore.generated.model.Status;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class JsonConverterTest {
+    JsonConverter jsonConverter = new JsonConverter();
+
+    static String uuid = "bcb032e2-d78b-4db1-bdea-f7248530f86d";
+    static String utcTime = "2021-05-26T19:18:51.232Z";
+    static String utcTime2 = "2021-12-28T01:12:48.885Z";
+    static String utcTime3 = "2022-01-01T23:19:23.001Z";
+
+    @Test
+    public void batchConvert() {
+        Batch batch = Batch.builder()
+                .status(Status.ACTIVE)
+                .distillery(Distillery.justId(uuid))
+                .batchIdentifier("batchIdentifier")
+                .batchNumber(1)
+                .completedAt(new Temporal.DateTime(utcTime))
+                .updatedAt(new Temporal.DateTime(utcTime))
+                .type("whiskey")
+                .build();
+        String json = jsonConverter.batchToJson(batch);
+        Batch deserializedBatch = jsonConverter.batchFromJson(json);
+        assertEquals(batch, deserializedBatch);
+    }
+
+    @Test
+    public void measuremnetConvert() {
+        Measurement measurement = Measurement.builder()
+                .trueProof(99.0)
+                .temperature(99.0)
+                .hydrometer(99.0)
+                .temperatureCorrection(99.0)
+                .hydrometerCorrection(99.0)
+                .batch(Batch.justId(uuid))
+                .createdAt(new Temporal.DateTime(utcTime))
+                .takenAt(new Temporal.DateTime(utcTime2))
+                .updatedAt(new Temporal.DateTime(utcTime3))
+                .note("Note")
+                .flag(false)
+                .build();
+        String json = jsonConverter.measurementToJson(measurement);
+        Measurement deserializedMeasurement = jsonConverter.measurementFromJson(json);
+        assertEquals(measurement, deserializedMeasurement);
+    }
+}


### PR DESCRIPTION
Created deserializer for AWS DateTime so that the DateTime fields get populated when getting an object from Json. The deserializer is registered with the Gson object in the JsonConverter file.